### PR TITLE
support "base" option for router in terminal link

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -27,7 +27,7 @@ async function start() {
   // Listen the server
   app.listen(port, host)
   consola.ready({
-    message: `Server listening on http://${host}:${port}`,
+    message: `Server listening on http://${host}:${port}${config.router.base || ''}`,
     badge: true
   })
 }


### PR DESCRIPTION
To fully support SSR, "base" option should be set both in `nuxt.config`'s "router" and `router/index.js` files.